### PR TITLE
🔥 remove redundant api-id flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,6 @@ func Run() {
 	}
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{Destination: &o.Host, Name: "host", Usage: "The hostname of the VyOS HTTP API.", EnvVars: []string{"VYCONFIGURE_HOST"}},
-		&cli.StringFlag{Destination: &o.ApiId, Name: "api-id", Usage: "API ID for the HTTP API.", EnvVars: []string{"VYCONFIGURE_API_ID"}},
 		&cli.StringFlag{Destination: &o.ApiKey, Name: "api-key", Usage: "API key for the HTTP API.", EnvVars: []string{"VYCONFIGURE_API_KEY"}},
 		&cli.StringFlag{Destination: &o.ConfigDirectory, Name: "config-dir", Value: ".", Usage: "Directory where config is stored.", EnvVars: []string{"VYCONFIGURE_CONFIG_DIR"}},
 		&cli.BoolFlag{Destination: &o.Insecure, Name: "insecure", Usage: "Whether to skip verifying the SSL certificate.", EnvVars: []string{"VYCONFIGURE_INSECURE"}},

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -4,7 +4,6 @@ import "github.com/urfave/cli/v2"
 
 type Options struct {
 	Host            string
-	ApiId           string
 	ApiKey          string
 	ConfigDirectory string
 	Insecure        bool
@@ -13,7 +12,6 @@ type Options struct {
 func GetOptions(c *cli.Context) *Options {
 	return &Options{
 		Host:            c.String("host"),
-		ApiId:           c.String("api-id"),
 		ApiKey:          c.String("api-key"),
 		ConfigDirectory: c.String("config-dir"),
 		Insecure:        c.Bool("insecure"),


### PR DESCRIPTION
The `api-id` flag is not used, this PR removed the redundant flag